### PR TITLE
Accept HTTP response of 204 as well as 200

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -162,7 +162,7 @@ class Roku(object):
         func = getattr(self._conn, method.lower())
         resp = func(url, *args, **kwargs)
 
-        if resp.status_code != 200:
+        if resp.status_code not in [200, 204]:
             raise RokuException(resp.content)
 
         return resp.content


### PR DESCRIPTION
Updated _call to accept response of 204 or 200.

Roku will return a 204 if being requested to launch an app that is already running.