### PR TITLE
Separate package from jcarbaugh version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=readme,
     author='Jeremy Carbaugh',
     author_email='jcarbaugh@gmail.com',
-    url='https://github.com/jcarbaugh/python-roku',
+    url='https://github.com/bah2830/python-roku',
     packages=find_packages(),
     install_requires=[
         'requests>=2.1.0',


### PR DESCRIPTION
I'm sorry for using a PR as an issue.
However this repo is used from home-assistant which I'm trying to improve.

The `README` installation instructions say `pip install roku` which will install jcarbaugh's version.

Would it be possible to create a pypi package for this fork?

home-assistant/home-assistant#7069
