### PR TITLE
Support for launching tv tuner and optionally changing channel

### DIFF
--- a/roku/core.py
+++ b/roku/core.py
@@ -238,6 +238,9 @@ class Roku(object):
             raise RokuException('this app belongs to another Roku')
         return self._post('/launch/%s' % app.id)
 
+    def channel(self, ch=""):
+        return self._post('/launch/tvinput.dtv?ch=%s' % ch)
+
     def store(self, app):
         return self._post('/launch/11', params={'contentID': app.id})
 


### PR DESCRIPTION
This adds the ability to easily launch the digital TV tuner app on a Roku TV and optionally change to a specific channel.


Example:
```python
r = Roku('192.168.1.200')
r.channel("2.1")   # Launches TV tuner and sets channel to 2.1
r.channel()        # Launches TV tuner to the last watched channel
```
I've tested this with a TCL Roku TV.
